### PR TITLE
将go-sql-driver/mysql改成meican-dev/mysql

### DIFF
--- a/types.go
+++ b/types.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/go-sql-driver/mysql"
+	"github.com/meican-dev/mysql"
 )
 
 //

--- a/types_test.go
+++ b/types_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-sql-driver/mysql"
+	"github.com/meican-dev/mysql"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
iyee/dbr里在存储时间类型的数据时，将时间转化为Local 时间存储。但是，在读取数据时，driver设置数据的时区为UTC，因此，读出来的时间为同样数据的UTC时间。meican-dev/sql这个目录fork了go-sql-driver/mysql，并设置在读取时间时设置时区为Local，解决了时间错误的问题。
